### PR TITLE
Stop using the now-released pre-release header

### DIFF
--- a/lib/index.rb
+++ b/lib/index.rb
@@ -16,7 +16,6 @@ require 'time'
 
 @headers = {
   "Content-Type": 'application/json',
-  "Accept": 'application/vnd.github.antiope-preview+json',
   "Authorization": "Bearer #{@GITHUB_TOKEN}",
   "User-Agent": 'rubocop-action'
 }


### PR DESCRIPTION
The feature was released, the specific header is no longer required:

https://developer.github.com/changes/2020-10-01-graduate-antiope-preview/