### PR TITLE
[CHORE] Add native build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.7-alpine
 
 LABEL com.github.actions.name="Rubocop checks"
 LABEL com.github.actions.description="Lint your Ruby code in parallel to your builds"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,7 @@ LABEL com.github.actions.color="red"
 LABEL maintainer="Alberto Gimeno <gimenete@gmail.com>"
 
 COPY lib /action/lib
+
+RUN apk add gcc musl-dev make
+
 ENTRYPOINT ["/action/lib/entrypoint.sh"]

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -6,6 +6,7 @@ require 'time'
 @GITHUB_EVENT_PATH = ENV["GITHUB_EVENT_PATH"]
 @GITHUB_TOKEN = ENV["GITHUB_TOKEN"]
 @GITHUB_WORKSPACE = ENV["GITHUB_WORKSPACE"]
+@RUBOCOP_CMD = ENV.fetch("RUBOCOP_CMD", "rubocop --format json")
 
 @event = JSON.parse(File.read(ENV["GITHUB_EVENT_PATH"]))
 @repository = @event["repository"]
@@ -76,7 +77,7 @@ def run_rubocop
   annotations = []
   errors = nil
   Dir.chdir(@GITHUB_WORKSPACE) {
-    errors = JSON.parse(`rubocop --format json`)
+    errors = JSON.parse(`#{@RUBOCOP_CMD}`)
   }
   conclusion = "success"
   count = 0


### PR DESCRIPTION
Arguably we should gem install rubocop at image build time but anyway, it's not much of a difference in a Github Action. It seems like one or more gem dependencies have started building native extensions so it fails to build without a compiler, stdio headers and make.